### PR TITLE
Update Debian image version

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -54,7 +54,7 @@ func (cmd *CreateCmd) Run(ctx context.Context, options *options.Options, log log
 	opts := ovhcloud.CreateInstanceOptions{
 		Name:      options.MachineID,
 		Flavor:    options.Flavor,
-		Image:     "Debian 10 - Docker",
+		Image:     "Debian 12 - Docker",
 		PublicKey: publicKey,
 	}
 


### PR DESCRIPTION
It looks like the Debian 10 image version is deprecated.

<img width="1084" alt="image" src="https://github.com/user-attachments/assets/e2872669-bd51-487d-bbc7-f4bfba77eeb3" />

So before the removal, it's better to use an uptodate Debian image version (Debian 12).

<img width="772" alt="image" src="https://github.com/user-attachments/assets/3a5492db-ce0f-4ec1-ac69-96c5a4a0a60a" />
